### PR TITLE
Dawn machine only spends essentia to generate

### DIFF
--- a/src/main/java/talonos/blightbuster/tileentity/DawnMachineTileEntity.java
+++ b/src/main/java/talonos/blightbuster/tileentity/DawnMachineTileEntity.java
@@ -361,8 +361,7 @@ public class DawnMachineTileEntity extends TileEntity implements IAspectSource, 
                 if (foundTopBlock) {
                     BiomeGenBase biome = getWorldObj().getBiomeGenForCoords(lastCleanseX+x, lastCleanseZ+z);
                     String biomeName = biome.biomeName.toLowerCase(Locale.ENGLISH);
-
-                    //Default to oak
+                    
                     if (biomeName.contains("desert")) {
                     	int chance = rand.nextInt(200) + 1;
                     	boolean block = rand.nextBoolean();
@@ -372,13 +371,10 @@ public class DawnMachineTileEntity extends TileEntity implements IAspectSource, 
                     		}
                     		else {
                                 getWorldObj().setBlock(lastCleanseX+x, topBlock + 1, lastCleanseZ+z, ConfigBlocks.blockCustomPlant, 3, 3);
-
                     		}
+                            spend(DawnMachineResource.ARBOR);
                     	}
-                        spend(DawnMachineResource.ARBOR);
                     }
-
- 
                 }
                 
             }


### PR DESCRIPTION
Removed comment "Default to oak": There was no oak
Made dawn machine only spend essentia when generating cactus/cinderpearl (not every desert blocks)