### PR TITLE
Update DawnMachineSpoutTileEntity.java

### DIFF
--- a/src/main/java/talonos/blightbuster/tileentity/DawnMachineSpoutTileEntity.java
+++ b/src/main/java/talonos/blightbuster/tileentity/DawnMachineSpoutTileEntity.java
@@ -165,7 +165,7 @@ public class DawnMachineSpoutTileEntity extends TileEntity implements IEssentiaT
 
 	@Override
 	public int addEssentia(Aspect aspect, int amount, ForgeDirection face) {
-		return canInputFrom(face) && getEssentiaType(forgeDirection) == aspect ? amount - addToContainer(aspect, amount) : 0;
+		return canInputFrom(face) && getEssentiaType(face) == aspect ? amount - addToContainer(aspect, amount) : 0;
 	}
 
 	@Override

--- a/src/main/java/talonos/blightbuster/tileentity/DawnMachineSpoutTileEntity.java
+++ b/src/main/java/talonos/blightbuster/tileentity/DawnMachineSpoutTileEntity.java
@@ -160,12 +160,12 @@ public class DawnMachineSpoutTileEntity extends TileEntity implements IEssentiaT
 
 	@Override
 	public int takeEssentia(Aspect aspect, int amount, ForgeDirection face) {
-		return (canOutputTo(face)) && (takeFromContainer(aspect, amount)) ? amount : 0;
+		return 0;
 	}
 
 	@Override
 	public int addEssentia(Aspect aspect, int amount, ForgeDirection face) {
-		return canInputFrom(face) ? amount - addToContainer(aspect, amount) : 0;
+		return canInputFrom(face) && getEssentiaType(forgeDirection) == aspect ? amount - addToContainer(aspect, amount) : 0;
 	}
 
 	@Override


### PR DESCRIPTION
THEORETICALLY fixes the thing where essentia export busses can export to the wrong faces of blocks. Don't merge this without testing it!