### PR TITLE
Fix a bug where the purity focus consumes vis when right clicking a mob even if it does nothing

### DIFF
--- a/src/main/java/talonos/blightbuster/items/ItemPurityFocus.java
+++ b/src/main/java/talonos/blightbuster/items/ItemPurityFocus.java
@@ -57,8 +57,8 @@ public class ItemPurityFocus extends ItemFocusBasic {
         }
 
         Entity pointedEntity = EntityUtils.getPointedEntity(p.worldObj, p, 0.0D, 32.0D, 32.0F);
-        if (pointedEntity != null && !world.isRemote) {
-            CleansingHelper.cleanseMobFromMapping(pointedEntity, pointedEntity.worldObj);
+        if (pointedEntity != null && !world.isRemote
+            && CleansingHelper.cleanseMobFromMapping(pointedEntity, pointedEntity.worldObj)) {
             wand.consumeAllVis(itemstack, p, this.getVisCost(itemstack), true, false);
         }
         boolean consumeVis = false;


### PR DESCRIPTION
The purity focus would constantly consume vis if you held right click while looking at any entity. Now it only consumes it when it actually does something.