### PR TITLE
Purity Focus Upgrade Potency

### DIFF
--- a/src/main/java/talonos/blightbuster/items/ItemPurityFocus.java
+++ b/src/main/java/talonos/blightbuster/items/ItemPurityFocus.java
@@ -138,8 +138,10 @@ public class ItemPurityFocus extends ItemFocusBasic implements IArchitect {
         } else if (doBlightBuster(itemstack, p, entity, wand, focus)) {
             if (p.worldObj.isRemote) {
                 PurityFocusFX.fire(entity, p);
-            } else {
-                entity.attackEntityFrom(new EntityDamageSource("magic", p), BlightbusterConfig.attackStrength);
+            } else { // 20% attack boost with extra potency from runes
+                entity.attackEntityFrom(
+                    new EntityDamageSource("magic", p),
+                    BlightbusterConfig.attackStrength * (5 + wand.getFocusPotency(itemstack)) / 5.0F);
                 wand.consumeAllVis(itemstack, p, getAttackVisCost(), true, false);
             }
             return true;
@@ -153,8 +155,8 @@ public class ItemPurityFocus extends ItemFocusBasic implements IArchitect {
         } else if (doCurative(itemstack, p, entity, wand, focus)) {
             if (p.worldObj.isRemote) {
                 PurityFocusFX.heal(entity, p);
-            } else {
-                entity.heal(BlightbusterConfig.healStrength);
+            } else { // +1 health with extra potency from runes
+                entity.heal(BlightbusterConfig.healStrength + wand.getFocusPotency(itemstack));
                 wand.consumeAllVis(itemstack, p, getHealVisCost(), true, false);
             }
             return true;


### PR DESCRIPTION
Wands with runes (primal and dreamwood staff) add a level of potency. This buffs Blight Buster's damage by 20% and buffs Curative's heal by 1 heart of healing per level of potency (should only ever be 1, but it should scale properly if something gives it a higher level of potency somehow).